### PR TITLE
Add gear feedback field to CanControl

### DIFF
--- a/src/yhs_can_control/include/yhs_can_control/yhs_can_control_node.hpp
+++ b/src/yhs_can_control/include/yhs_can_control/yhs_can_control_node.hpp
@@ -54,7 +54,7 @@ namespace yhs
     int can_socket_;
     std::thread thread_;
 
-    uint8_t ctrl_fb_gear_;
+    uint8_t ctrl_fb_gear_{0};
 
     std::vector<int64_t> ultrasonic_number_;
 


### PR DESCRIPTION
## Summary
- initialize `ctrl_fb_gear_` member to track gear feedback

## Testing
- `colcon build --packages-select yhs_can_control` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a431a700948329866a188ced0673ee